### PR TITLE
Fixed sorting SRV records

### DIFF
--- a/xmpp/transports.py
+++ b/xmpp/transports.py
@@ -83,7 +83,7 @@ class TCPsocket(PlugIn):
                     if HAVE_DNSPYTHON:
                         answers = [x for x in dns.resolver.query(query, 'SRV')]
                         # Sort by priority, according to RFC 2782.
-                        answers.sort(answers, key=lambda a: a.priority)
+                        answers.sort(key=lambda a: a.priority)
                         if answers:
                             host = str(answers[0].target)
                             port = int(answers[0].port)


### PR DESCRIPTION
Hi,

I fixed sorting the results of a SRV dns query, I removed the variable name from the line answers.sort(key=lambda aL a.priority). with this change the module works fine with two SRV records. 

If you agree with this change please except this pull-request.

cheers,

Johan
