### PR TITLE
Crashfix: 'From' jid with a non-ASCII char sending a command

### DIFF
--- a/xmpp/commands.py
+++ b/xmpp/commands.py
@@ -72,7 +72,7 @@ class Commands(PlugIn):
         # We must:
         #   Pass on command execution to command handler
         #   (Do we need to keep session details here, or can that be done in the command?)
-        jid = str(request.getTo())
+        jid = unicode(request.getTo())
         try:
             node = request.getTagAttr('command','node')
         except:
@@ -103,7 +103,7 @@ class Commands(PlugIn):
             #   To make this code easy to write we add an 'list' disco type, it returns a tuple or 'none' if not advertised
             list = []
             items = []
-            jid = str(request.getTo())
+            jid = unicode(request.getTo())
             # Get specific jid based results
             if self._handlers.has_key(jid):
                 for each in self._handlers[jid].keys():


### PR DESCRIPTION
Fixes a crash occurring when a remote jid with a
non-ASCII character issued a XEP-0050 Ad-Hoc
command.

Specifically, jid=str(...) was changed to
jid=unicode(...) in commands.py. No side effects
observed.

It was sufficient to have a user called
"mačak@server.tld" to issue a command request
and the component would crash.
