### PR TITLE
Iq+XEP-0050: Fix erroneously generated <command/> in .buildReply()

### DIFF
--- a/xmpp/protocol.py
+++ b/xmpp/protocol.py
@@ -561,7 +561,6 @@ class Iq(Protocol):
         """ Builds and returns another Iq object of specified type.
             The to, from and query child node of new Iq are pre-set as reply to this Iq. """
         iq=Iq(typ,to=self.getFrom(),frm=self.getTo(),attrs={'id':self.getID()})
-        iq.setQuery(self.getQuery().getName()).setNamespace(self.getQueryNS())
         return iq
 
 class ErrorNode(Node):


### PR DESCRIPTION
In this patch, .buildReply() for an Iq now no longer automatically calls setQuery(). This fixes old code (including the 'commandsbot.py' example!) which tries to add a new &lt;command /&gt; child instead of patching the pre-created one.
