### PR TITLE
Improve compatibility with Python 3 within authentication subsystem

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ xmpppy changelog
 
 in progress
 ===========
+- Improve compatibility with Python 3 within authentication subsystem
+
 
 
 2020-11-12 0.6.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ xmpppy changelog
 in progress
 ===========
 - Improve compatibility with Python 3 within authentication subsystem
-
+- Improve exception handling
 
 
 2020-11-12 0.6.2

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ README = open(os.path.join(here, 'README.rst')).read()
 
 # Set proper release version in source code also!!!
 setup(name='xmpppy',
-      version='0.6.2',
+      version='0.6.3-dev1',
       author='Alexey Nezhdanov',
       author_email='snakeru@users.sourceforge.net',
       url='http://xmpppy.sourceforge.net/',

--- a/xmpp/dispatcher.py
+++ b/xmpp/dispatcher.py
@@ -123,7 +123,10 @@ class Dispatcher(PlugIn):
             self.Stream.Parse(data)
             if len(self._pendingExceptions) > 0:
                 _pendingException = self._pendingExceptions.pop()
-                raise _pendingException[0](_pendingException[1]).with_traceback(_pendingException[2])
+                ex = _pendingException[0](_pendingException[1])
+                if hasattr(ex, "with_traceback"):
+                    ex = ex.with_traceback(_pendingException[2])
+                raise ex
             if data: return len(data)
         return '0'      # It means that nothing is received but link is alive.
 


### PR DESCRIPTION
Hi there,

this is an attempt to address #43. I tested it on Python 2.7.16 and Python 3.9.6 with the example provided by @M010, see https://github.com/xmpppy/xmpppy/issues/43#issuecomment-889022246 and have not been able to observe any regression on Python 2.

The patch includes a suggestion by @renyxa at https://github.com/xmpppy/xmpppy/pull/37#issuecomment-743785923. Thanks!

With kind regards,
Andreas.
