### PR TITLE
Remove special characters from README.rst

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ in progress
 ===========
 - Improve compatibility with Python 3 within authentication subsystem
 - Improve exception handling
+- Remove special characters from README.rst to make installation on Windows easier
 
 
 2020-11-12 0.6.2

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Regularly, the module is used as a library, like::
     jabberid = "foobar@xmpp.domain.tld"
     password = "secret"
     receiver = "bazqux@xmpp.domain.tld"
-    message  = "☠☠☠ hello world ☠☠☠"
+    message  = "hello world"
 
     jid = xmpp.protocol.JID(jabberid)
     connection = xmpp.Client(server=jid.getDomain(), debug=debug)
@@ -66,7 +66,7 @@ which can be invoked from the command line. Its synopsis is::
 
     xmpp-message --debug \
         --jabberid foobar@xmpp.domain.tld --password secret \
-        --receiver bazqux@xmpp.domain.tld --message '☠☠☠ hello world ☠☠☠'
+        --receiver bazqux@xmpp.domain.tld --message 'hello world'
 
 
 *************


### PR DESCRIPTION
Hi there,

@Kristopher38, @Brewsk11 and @novaws reported problems when installing this package from PyPI on Windows systems, because the README.rst file contains special characters.

This patch just removes those special characters on order to make installation on Windows easier.

With kind regards,
Andreas.
