### PR TITLE
Python 3: Fix handling of `socket.error`/`OSError` exceptions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ xmpppy changelog
 
 in progress
 ===========
+- Python 3: Fix handling of ``socket.error``/``OSError`` exceptions
 
 
 2021-09-14 0.6.3

--- a/xmpp/transports.py
+++ b/xmpp/transports.py
@@ -162,11 +162,13 @@ class TCPsocket(PlugIn):
                     self.DEBUG("Successfully connected to remote host %s"%repr(server),'start')
                     return 'ok'
                 except socket.error as xxx_todo_changeme:
-                    (errno, strerror) = xxx_todo_changeme.args
+                    errno = xxx_todo_changeme.args[0]
+                    strerror = xxx_todo_changeme.args[1]
                     if self._sock is not None: self._sock.close()
             self.DEBUG("Failed to connect to remote host %s: %s (%s)"%(repr(server), strerror, errno),'error')
         except socket.gaierror as xxx_todo_changeme1:
-            (errno, strerror) = xxx_todo_changeme1.args
+            errno = xxx_todo_changeme1.args[0]
+            strerror = xxx_todo_changeme1.args[1]
             self.DEBUG("Failed to lookup remote host %s: %s (%s)"%(repr(server), strerror, errno),'error')
 
     def plugout(self):


### PR DESCRIPTION
Hi there,

@oxivanisher reported at #49:

> While trying to connect, the line [165 in `transports.py`](https://github.com/xmpppy/xmpppy/blob/db73250d5f8df24737e063c089e6d452e35116e1/xmpp/transports.py#L165) is failing, since the `socket.error` has a tuple with five elements but the current code only supports two.
>
> This exception is raised:
> ```
>   File "xxx\lib\site-packages\xmpp\transports.py", line 166, in connect
>     (errno, strerror) = xxx_todo_changeme.args
> ValueError: too many values to unpack (expected 2)
> ```

This patch aims to improve the situation.

With kind regards,
Andreas.
