### PR TITLE
Add CHANGES.rst and friends to release package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include setup.cfg *.txt *.rst *.md LICENSE
+recursive-include xmpp


### PR DESCRIPTION
Hi,

as reported by @gdt, the `xmpppy` packages on PyPI don't include a changelog. This patch accounts for that and will add the `CHANGES.rst`, `CONTRIBUTORS.rst`, `LICENSE` and `README.rst` files to the Python sdist release package tarball.

With kind regards,
Andreas.