### PR TITLE
Improve Python2/3 compatibility by using `six`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ xmpppy changelog
 
 in progress
 ===========
+- Use ``six.ensure_str()`` and ``six.ensure_binary()`` instead of custom decoding. Thanks, @normanr!
 
 
 2021-12-28 0.7.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ xmpppy changelog
 in progress
 ===========
 - Use ``six.ensure_str()`` and ``six.ensure_binary()`` instead of custom decoding. Thanks, @normanr!
-
+- Fix Non-SASL (XEP-0078) authentication for Python 3. Thanks, @smudge1977!
 
 2021-12-28 0.7.0
 ================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ in progress
 ===========
 - Use ``six.ensure_str()`` and ``six.ensure_binary()`` instead of custom decoding. Thanks, @normanr!
 - Fix Non-SASL (XEP-0078) authentication for Python 3. Thanks, @smudge1977!
+- Add ``B64`` shortcut function to streamline base64 encoding.
 
 2021-12-28 0.7.0
 ================

--- a/setup.py
+++ b/setup.py
@@ -45,4 +45,5 @@ setup(name='xmpppy',
               'xmpp-message = xmpp.cli:simple_message',
           ],
       },
+      install_requires="six",
   )

--- a/xmpp/auth.py
+++ b/xmpp/auth.py
@@ -38,6 +38,8 @@ def C(some):
 
 def HHSHA1(some):
     return sha1(ensure_binary(some, CHARSET_ENCODING)).hexdigest()
+def B64(some):
+    return ensure_str(base64.b64encode(ensure_binary(some,CHARSET_ENCODING)),CHARSET_ENCODING)
 
 class NonSASL(PlugIn):
     """ Implements old Non-SASL (XEP-0078) authentication used in jabberd1.4 and transport authentication."""
@@ -154,8 +156,7 @@ class SASL(PlugIn):
             node=Node('auth',attrs={'xmlns':NS_SASL,'mechanism':'DIGEST-MD5'})
         elif "PLAIN" in mecs:
             sasl_data='%s\x00%s\x00%s'%(self.username+'@'+self._owner.Server,self.username,self.password)
-            payload = base64.b64encode(sasl_data.encode(CHARSET_ENCODING)).decode(CHARSET_ENCODING).replace('\r','').replace('\n','')
-            node=Node('auth',attrs={'xmlns':NS_SASL,'mechanism':'PLAIN'},payload=[payload])
+            node=Node('auth',attrs={'xmlns':NS_SASL,'mechanism':'PLAIN'},payload=[B64(sasl_data)])
         else:
             self.startsasl='failure'
             self.DEBUG('I can only use DIGEST-MD5 and PLAIN mecanisms.','error')
@@ -214,7 +215,7 @@ class SASL(PlugIn):
                 if key in ['nc','qop','response','charset']: sasl_data+="%s=%s,"%(key,resp[key])
                 else: sasl_data+='%s="%s",'%(key,resp[key])
 ########################################3333
-            node=Node('response',attrs={'xmlns':NS_SASL},payload=[base64.b64encode(sasl_data[:-1].encode()).decode().replace('\r','').replace('\n','')])
+            node=Node('response',attrs={'xmlns':NS_SASL},payload=[B64(sasl_data[:-1])])
             self._owner.send(node.__str__())
         elif 'rspauth' in chal: self._owner.send(Node('response',attrs={'xmlns':NS_SASL}).__str__())
         else:

--- a/xmpp/debug.py
+++ b/xmpp/debug.py
@@ -43,6 +43,7 @@ import sys
 import traceback
 import time
 import os
+from six import ensure_str
 
 import types
 
@@ -396,8 +397,7 @@ class Debug:
 
     colors={}
     def Show(self, flag, msg, prefix=''):
-        if isinstance(msg, bytes):
-            msg = msg.decode('utf-8')
+        msg=ensure_str(msg,'utf-8')
         msg=msg.replace('\r','\\r').replace('\n','\\n').replace('><','>\n  <')
         if not colors_enabled: pass
         elif prefix in self.colors: msg=self.colors[prefix]+msg+color_none

--- a/xmpp/transports.py
+++ b/xmpp/transports.py
@@ -40,6 +40,7 @@ from errno import ECONNREFUSED
 import random
 import gzip
 from io import StringIO
+from six import ensure_binary
 try:
     from urllib2 import urlparse
     urlparse = urlparse.urlparse
@@ -224,8 +225,7 @@ class TCPsocket(PlugIn):
         #print('type:', type(raw_data))
         if type(raw_data)==type(''): raw_data = raw_data
         elif type(raw_data)!=type(''): raw_data = ustr(raw_data)
-        if sys.version_info.major >= 3:
-            raw_data = raw_data.encode('utf-8')
+        raw_data=ensure_binary(raw_data,'utf-8')
         try:
             sent = 0
             while not sent:


### PR DESCRIPTION
Dear @normanr,

thank you very much for your insights and suggestions at https://github.com/xmpppy/xmpppy/pull/58#discussion_r823072587.

> What would you think about adopting the `six` helper functions instead (assuming that adding the dependency on the `six` library is acceptable)?

This patch attempts to implement your suggestion as I don't have any objections.
- a2553fa19 removes the custom decoding routines and the conditional checks for `isinstance(lalala, str|bytes)` introduced the other day by switching to `six.ensure_str|ensure_binary` instead.
- db66c19db attempts to improve the situation for @smudge1977, regarding #38 and #58. For that purpose, it introduces a helper function `HHSHA1`. While such a label is not referenced in any specification, I believe it will do no harm to have such a helper function similar to the others `H`, `HH` and `C`?
- e12316d1fb will also use `six.ensure_str|ensure_binary` for streamlining the base64 encoding which happens at two places within `auth.py`. For this purpose, it introduces a helper function `B64`.

With kind regards,
Andreas.

P.S.: I haven't tested the patch and I am also probably missing an appropriate rig, so I am humbly asking the community to give it a try and report back.

/cc @sumdog, @gdt, @D-L, @rogue73, @SHFRGRP, @mnswdhw
