### PR TITLE
Update to handling of JID creation: Don't set `domain` attribute on specific conditions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ in progress
 - Use ``six.ensure_str()`` and ``six.ensure_binary()`` instead of custom decoding. Thanks, @normanr!
 - Fix Non-SASL (XEP-0078) authentication for Python 3. Thanks, @smudge1977!
 - Add ``B64`` shortcut function to streamline base64 encoding.
+- Update to handling of JID creation: Don't set ``domain`` attribute on specific conditions.
+  Thanks, @smudge1977!
+
 
 2021-12-28 0.7.0
 ================

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,0 +1,36 @@
+import pytest
+from xmpp.protocol import *
+
+
+class Test_JID():
+
+    def test_equality(self):
+        assert 'me@myserver/res' == JID('me@myserver/res')
+
+    def test_1(self):
+        jid = JID('audiod/Jcop')
+        assert jid.getDomain() == ''
+        assert jid.getNode() == 'audiod'
+        assert jid.getResource() == 'Jcop'
+
+    def test_2(self):
+        jid = JID('audiod@ics/Jcop')
+        assert jid.getDomain() == 'ics'
+        assert jid.getNode() == 'audiod'
+        assert jid.getResource() == 'Jcop'
+
+    def test_3(self):
+        jid = JID('audiod')
+        assert jid.getDomain() == ''
+        assert jid.getNode() == 'audiod'
+        assert jid.getResource() == ''
+
+    def test_4(self):
+        jid = JID('audiod@ics')
+        assert jid.getDomain() == 'ics'
+        assert jid.getNode() == 'audiod'
+        assert jid.getResource() == ''
+
+
+t = Test_JID()
+t.test_equality()

--- a/xmpp/protocol.py
+++ b/xmpp/protocol.py
@@ -280,6 +280,9 @@ class JID:
             else: self.node=''
             if jid.find('/')+1: self.domain,self.resource=jid.split('/',1)
             else: self.domain,self.resource=jid,''
+        if self.node == '':
+            self.node = self.domain
+            self.domain = ''
     def getNode(self):
         """ Return the node part of the JID """
         return self.node


### PR DESCRIPTION
Hi there,

this is the gist from the patch submitted by @smudge1977 on behalf of #61. It resolves #57 for him. I've cherry-picked cd82665e56 which became bd2344c69 with further adjustments.

I want to apologize that I don't know enough about the XMPP specifications to judge if that amendment has a good purpose for the cases @smudge1977 needs it. So, may I humbly ask you again to review this patch, @normanr?

With kind regards,
Andreas.
