### PR TITLE
SCRAM-SHA-256 и SCRAM-SHA-256-PLUS

### DIFF
--- a/xmpp/auth.py
+++ b/xmpp/auth.py
@@ -23,7 +23,8 @@ from .protocol import *
 from .client import PlugIn
 import base64,random,re
 from . import dispatcher
-from hashlib import md5,sha1
+import hmac
+from hashlib import md5,sha1,sha256,pbkdf2_hmac
 from six import ensure_str,ensure_binary
 
 CHARSET_ENCODING='utf-8'
@@ -113,6 +114,8 @@ class SASL(PlugIn):
         PlugIn.__init__(self)
         self.username=username
         self.password=password
+        self.mechanism=None
+        self.scram_state={}
 
     def plugin(self,owner):
         if 'version' not in self._owner.Dispatcher.Stream._document_attrs: self.startsasl='not-supported'
@@ -150,17 +153,32 @@ class SASL(PlugIn):
         self._owner.RegisterHandler('challenge',self.SASLHandler,xmlns=NS_SASL)
         self._owner.RegisterHandler('failure',self.SASLHandler,xmlns=NS_SASL)
         self._owner.RegisterHandler('success',self.SASLHandler,xmlns=NS_SASL)
-        if "ANONYMOUS" in mecs and self.username == None:
+        node=None
+        use_plus=False
+        cb_type, cb_data = self._tls_channel_binding()
+        if "SCRAM-SHA-256-PLUS" in mecs and cb_data:
+            use_plus=True
+            node=self._build_scram_auth('SCRAM-SHA-256-PLUS', cb_type, cb_data)
+        elif "SCRAM-SHA-256" in mecs:
+            node=self._build_scram_auth('SCRAM-SHA-256')
+        elif "ANONYMOUS" in mecs and self.username == None:
+            self.mechanism='ANONYMOUS'
             node=Node('auth',attrs={'xmlns':NS_SASL,'mechanism':'ANONYMOUS'})
         elif "DIGEST-MD5" in mecs:
+            self.mechanism='DIGEST-MD5'
             node=Node('auth',attrs={'xmlns':NS_SASL,'mechanism':'DIGEST-MD5'})
         elif "PLAIN" in mecs:
+            self.mechanism='PLAIN'
             sasl_data='%s\x00%s\x00%s'%(self.username+'@'+self._owner.Server,self.username,self.password)
             node=Node('auth',attrs={'xmlns':NS_SASL,'mechanism':'PLAIN'},payload=[B64(sasl_data)])
         else:
             self.startsasl='failure'
-            self.DEBUG('I can only use DIGEST-MD5 and PLAIN mecanisms.','error')
+            self.DEBUG('I can only use SCRAM-SHA-256(+), DIGEST-MD5 and PLAIN mecanisms.','error')
             return
+        if use_plus:
+            self.mechanism='SCRAM-SHA-256-PLUS'
+        elif node and not self.mechanism:
+            self.mechanism=node.getAttr('mechanism')
         self.startsasl='in-process'
         self._owner.send(node.__str__())
         raise NodeProcessed
@@ -175,6 +193,14 @@ class SASL(PlugIn):
             self.DEBUG('Failed SASL authentification: %s'%reason,'error')
             raise NodeProcessed
         elif challenge.getName()=='success':
+            if self.mechanism and self.mechanism.startswith('SCRAM-SHA-256') and challenge.getData():
+                data=ensure_str(base64.b64decode(challenge.getData()),CHARSET_ENCODING)
+                attrs=self._scram_parse(data)
+                expected=self.scram_state.get('server_signature')
+                if expected and attrs.get('v')!=expected:
+                    self.startsasl='failure'
+                    self.DEBUG('SCRAM server signature mismatch','error')
+                    raise NodeProcessed
             self.startsasl='success'
             self.DEBUG('Successfully authenticated with remote server.','ok')
             handlers=self._owner.Dispatcher.dumpHandlers()
@@ -184,6 +210,10 @@ class SASL(PlugIn):
             self._owner.User=self.username
             raise NodeProcessed
 ########################################3333
+        if self.mechanism and self.mechanism.startswith('SCRAM-SHA-256'):
+            self._handle_scram_challenge(challenge)
+            raise NodeProcessed
+
         incoming_data=challenge.getData()
         chal={}
         data=base64.b64decode(incoming_data)
@@ -222,6 +252,102 @@ class SASL(PlugIn):
             self.startsasl='failure'
             self.DEBUG('Failed SASL authentification: unknown challenge','error')
         raise NodeProcessed
+
+    # ---- SCRAM-SHA-256 helpers ----
+    def _tls_channel_binding(self):
+        """Return (cb_type, cb_data) if TLS channel binding data is available."""
+        try:
+            conn = getattr(self._owner, 'Connection', None)
+            sslobj = getattr(conn, '_sslObj', None)
+            if not sslobj:
+                return (None, None)
+            if hasattr(sslobj, 'version') and sslobj.version() and 'TLSv1.3' in sslobj.version():
+                if hasattr(sslobj, 'export_keying_material'):
+                    data = sslobj.export_keying_material(b"EXPORTER-Channel-Binding", 32, b"")
+                    return ('tls-exporter', data)
+            if hasattr(sslobj, 'get_channel_binding'):
+                data = sslobj.get_channel_binding('tls-unique')
+                if data:
+                    return ('tls-unique', data)
+        except Exception as exc:
+            self.DEBUG('Channel binding unavailable: %s'%exc,'warn')
+        return (None, None)
+
+    def _scram_escape(self,value):
+        return value.replace('=','=3D').replace(',','=2C')
+
+    def _scram_build_gs2(self,cb_type=None):
+        if cb_type:
+            return 'p=%s,,'%(cb_type)
+        return 'n,,'
+
+    def _build_scram_auth(self, mechanism, cb_type=None, cb_data=b''):
+        self.mechanism=mechanism
+        nonce_bytes=random.randbytes(18) if hasattr(random,'randbytes') else bytes([random.randint(0,255) for _ in range(18)])
+        nonce=base64.b64encode(nonce_bytes).decode('ascii')
+        gs2_header=self._scram_build_gs2(cb_type if mechanism.endswith('PLUS') else None)
+        client_first_bare='n=%s,r=%s'%(self._scram_escape(self.username),nonce)
+        client_first_message=gs2_header+client_first_bare
+        self.scram_state={
+            'gs2':gs2_header,
+            'nonce':nonce,
+            'client_first_bare':client_first_bare,
+            'server_first':None,
+            'cb_data':cb_data if mechanism.endswith('PLUS') else b'',
+        }
+        return Node('auth',attrs={'xmlns':NS_SASL,'mechanism':mechanism},payload=[B64(client_first_message)])
+
+    def _scram_parse(self, data):
+        attrs={}
+        for item in data.split(','):
+            if '=' in item:
+                k,v=item.split('=',1)
+                attrs[k]=v
+        return attrs
+
+    def _handle_scram_challenge(self,challenge):
+        incoming_data=challenge.getData()
+        data=ensure_str(base64.b64decode(incoming_data),CHARSET_ENCODING)
+        attrs=self._scram_parse(data)
+        self.DEBUG('Got SCRAM challenge: '+data,'ok')
+        if 'e' in attrs:
+            self.startsasl='failure'
+            self.DEBUG('SCRAM error: %s'%attrs.get('e'),'error')
+            return
+        state=self.scram_state
+        if state.get('server_first') is None:
+            # server-first message
+            combined_nonce=attrs.get('r','')
+            if not combined_nonce.startswith(state['nonce']):
+                self.startsasl='failure'
+                self.DEBUG('SCRAM nonce mismatch','error')
+                return
+            salt=base64.b64decode(attrs.get('s',''))
+            iterations=int(attrs.get('i','0'))
+            if iterations<=0:
+                self.startsasl='failure'
+                self.DEBUG('SCRAM invalid iteration count','error')
+                return
+            gs2header=state['gs2']
+            cb_data=state.get('cb_data',b'')
+            cbind=B64(gs2header.encode(CHARSET_ENCODING)+cb_data)
+            salted=pbkdf2_hmac('sha256',ensure_binary(self.password,CHARSET_ENCODING),salt,iterations)
+            client_key=hmac.new(salted,b"Client Key",sha256).digest()
+            stored_key=sha256(client_key).digest()
+            client_final_no_proof='c=%s,r=%s'%(cbind,combined_nonce)
+            auth_message=','.join([state['client_first_bare'],data,client_final_no_proof])
+            client_signature=hmac.new(stored_key,ensure_binary(auth_message,CHARSET_ENCODING),sha256).digest()
+            proof=bytes([a ^ b for a,b in zip(client_key,client_signature)])
+            server_key=hmac.new(salted,b"Server Key",sha256).digest()
+            server_signature=hmac.new(server_key,ensure_binary(auth_message,CHARSET_ENCODING),sha256).digest()
+            state['server_signature']=base64.b64encode(server_signature).decode('ascii')
+            state['server_first']=data
+            resp='%s,p=%s'%(client_final_no_proof,base64.b64encode(proof).decode('ascii'))
+            node=Node('response',attrs={'xmlns':NS_SASL},payload=[B64(resp)])
+            self._owner.send(node.__str__())
+        else:
+            # Should not reach here because success handled separately
+            self.DEBUG('Unexpected SCRAM challenge state','warn')
 
 class Bind(PlugIn):
     """ Bind some JID to the current connection to allow router know of our location."""


### PR DESCRIPTION
Реализована поддержка механизмов аутентификации SCRAM-SHA-256 и SCRAM-SHA-256-PLUS в SASL Добавлена обработка channel binding для SCRAM-SHA-256-PLUS (tls-exporter/tls-unique) Проведена генерация client proof и верификация server signature согласно RFC 7677/5802