### PR TITLE
Tests: Add configuration for code coverage reporting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,3 +58,14 @@ jobs:
       run: |
         docker compose --file tests/compose.yml up --detach --wait
         pytest
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      with:
+        files: ./coverage.xml
+        flags: unittests
+        env_vars: OS,PYTHON
+        name: codecov-umbrella
+        fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *.pyc
 .venv*
 /build
+.coverage
+coverage.xml
 /dist
 /html
 .*.swp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 minversion = "2.0"
 addopts = """
   -rfEX -p pytester --strict-markers --verbosity=3
+  --cov --cov-report=term-missing --cov-report=xml
   """
 log_level = "DEBUG"
 log_cli_level = "DEBUG"
@@ -13,6 +14,7 @@ markers = [
 [tool.coverage.run]
 branch = false
 source = ["xmpp"]
+patch = ["subprocess"]
 
 [tool.coverage.report]
 fail_under = 0


### PR DESCRIPTION
A followup to GH-74, now configuring pytest-cov properly, and adding a CI configuration snippet for uploading to Codecov.