### PR TITLE
Fix "wait" and "route" params for Bosh transport (2026)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ xmpppy changelog
 
 in progress
 ===========
+- Fixed ``wait`` and ``route`` parameters for Bosh transport. Thanks, @soul4code.
 
 2025-08-09 0.7.2
 ================

--- a/xmpp/transports.py
+++ b/xmpp/transports.py
@@ -457,7 +457,7 @@ class Bosh(PlugIn):
         self.use_srv = use_srv
         self.Sid = None
         self._rid = 0
-        self.wait = 80
+        self.wait = wait
         self.hold = hold
         self.requests = requests
         self._pipeline = None
@@ -675,7 +675,8 @@ class Bosh(PlugIn):
                         route = '%s:%s' % self._server, self._port
                     else:
                         route = self._server
-                    body.setAttr('route', route)
+                    if route:
+                        body.setAttr('route', route)
         else:
             # Mid stream, wrap the xml stanza in a BOSH body wrapper
             if stream:


### PR DESCRIPTION
@soul4code submitted this patch the other day per GH-23, actually more than ten years ago. Thank you in retrospective!

> Fix "wait" and "route" params for Bosh transport.

@Neustradamus: Please also review and acknowledge. Can you possibly verify?
