### PR TITLE
Fix `receive` when message is empty

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ xmpppy changelog
 in progress
 ===========
 - Fixed ``wait`` and ``route`` parameters for Bosh transport. Thanks, @soul4code.
+- Fixed ``receive`` when message is empty. Thanks, @soul4code.
 
 2025-08-09 0.7.2
 ================

--- a/xmpp/transports.py
+++ b/xmpp/transports.py
@@ -542,6 +542,8 @@ class Bosh(PlugIn):
 
     def receive(self):
         resp = ''
+        if len(self._respobjs) == 0:
+            return resp
         if self.PIPELINE:
             res, data = self._respobjs.pop(0)
         else:


### PR DESCRIPTION
@soul4code submitted this patch the other day per GH-23, actually more than ten years ago. Thank you in retrospective!

> Fix receive