### PR TITLE
Fix for unicode

### DIFF
--- a/xmpp/dispatcher.py
+++ b/xmpp/dispatcher.py
@@ -120,6 +120,7 @@ class Dispatcher(PlugIn):
         if self._owner.Connection.pending_data(timeout):
             try: data=self._owner.Connection.receive()
             except IOError: return
+            data = data.encode('utf-8')
             self.Stream.Parse(data)
             if len(self._pendingExceptions) > 0:
                 _pendingException = self._pendingExceptions.pop()

--- a/xmpp/transports.py
+++ b/xmpp/transports.py
@@ -691,11 +691,11 @@ class Bosh(PlugIn):
         body.setAttr('rid', self.Rid)
         if self.Sid:
             body.setAttr('sid', self.Sid)
-        return str(body)
+        return str(body).encode('utf-8')
 
     def send(self, raw_data, headers={}):
         if type(raw_data) != type('') or type(raw_data) != type(''):
-            raw_data = str(raw_data)
+            raw_data = str(raw_data).encode('utf-8')
         bosh_data = self.xmlstream_to_bosh(raw_data)
         default = dict(self.headers)
         default['Host'] = self._http_host


### PR DESCRIPTION
## About
This has also been submitted by @soul4code within GH-23, specifically a2a3b19ad88ad2825ff8c84e6840998de8588aa6 without the whitespace diff noise.

## Thoughts
I suspect the patch is no longer applicable with Python 3.