### PR TITLE
Iq+XEP-0050: Fix erroneously generated `<command/>`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ in progress
 ===========
 - Fixed ``wait`` and ``route`` parameters for Bosh transport. Thanks, @soul4code.
 - Fixed ``receive`` when message is empty. Thanks, @soul4code.
+- Fixed erroneously generated ``<command/>`` in ``buildReply()`` (Iq+XEP-0050).
+  Thanks, @ivucica.
 
 2025-08-09 0.7.2
 ================

--- a/xmpp/protocol.py
+++ b/xmpp/protocol.py
@@ -561,7 +561,6 @@ class Iq(Protocol):
         """ Builds and returns another Iq object of specified type.
             The to, from and query child node of new Iq are pre-set as reply to this Iq. """
         iq=Iq(typ,to=self.getFrom(),frm=self.getTo(),attrs={'id':self.getID()})
-        iq.setQuery(self.getQuery().getName()).setNamespace(self.getQueryNS())
         return iq
 
 class ErrorNode(Node):


### PR DESCRIPTION
## About

This patch was conceived by @ivucica the other day. Thank you.

<blockquote>

`.buildReply()` for an Iq no longer automatically
calls `setQuery()`. This fixes old code (including
the `commandsbot.py` example) which tries to add
a new `<command/>` child instead of patching the
pre-created one.

</blockquote>

## References
- https://github.com/xmpppy/xmpppy/issues/12