### PR TITLE
Tests: Clean up after consolidating development dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,8 +51,7 @@ jobs:
 
     - name: Set up project
       run: |
-        pip install --upgrade --editable='.'
-        pip install -r requirements-test.txt
+        pip install --upgrade --editable='.[test]'
 
     - name: Run software tests
       run: |

--- a/README.rst
+++ b/README.rst
@@ -111,22 +111,16 @@ within the code base.
 Development
 ***********
 
-::
+Acquire sources and bootstrap sandbox::
 
     git clone https://github.com/xmpppy/xmpppy
     cd xmpppy
     python3 -m venv .venv
     source .venv/bin/activate
-    pip install --editable='.[test]' --upgrade
+    pip install --upgrade --editable='.[test]'
 
+Run software tests::
 
-**************
-Software tests
-**************
-
-::
-
-    pip install -r requirements-test.txt
     docker compose --file tests/compose.yml up
     pytest
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,0 @@
-pytest<10
-pytest-cov<8
-pytz


### PR DESCRIPTION
## About
Development dependencies have been defined in `setup.py` for a while, so using `requirements-test.txt` is no longer needed.