### PR TITLE
Remove Stanza once callback called to avoid memory ballooning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ in progress
 ===========
 - Fixed ``wait`` and ``route`` parameters for Bosh transport. Thanks, @soul4code.
 - Fixed ``receive`` when message is empty. Thanks, @soul4code.
+- Fixed memory leak by removing stanza once callback called.
+  Thanks, @CyrilPeponnet.
 
 2025-08-09 0.7.2
 ================

--- a/xmpp/dispatcher.py
+++ b/xmpp/dispatcher.py
@@ -293,6 +293,7 @@ class Dispatcher(PlugIn):
             user=0
             if type(session._expected[ID])==type(()):
                 cb,args=session._expected[ID]
+                del session._expected[ID]
                 session.DEBUG("Expected stanza arrived. Callback %s(%s) found!"%(cb,args),'ok')
                 try: cb(session,stanza,**args)
                 except Exception as typ:


### PR DESCRIPTION
## About
Submitting the commit https://github.com/ArchipelProject/xmpppy/commit/35c77e4 to fix a memory leak by @CyrilPeponnet. Thank you very much.

## Details
> Deleting `session._expected[ID]` when the callback will be processed avoid this dict to grow over the time.

## References
- GH-91
