### PR TITLE
Improve send performances when using SSL

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,12 @@ xmpppy changelog
 
 in progress
 ===========
+- Improved send performances when using SSL. Thanks, @CyrilPeponnet.
+
+  - Keep buffer between two tries to avoid SSL warning.
+  - Use ``socket.send`` instead of sendall for better exception catching.
+  - Set ``select.select`` timeout to ``0`` to avoid to block processing while
+    waiting.
 
 2026-02-08 0.7.3
 ================


### PR DESCRIPTION
## About
Submitting the commit https://github.com/ArchipelProject/xmpppy/commit/288b280c6ec534c100bfee871daa3bb707467a1a to improve performance with SSL by @CyrilPeponnet. Thank you very much.

## Review
Because cherry-picking failed here, I had to transfer code manually. In this spirit, the patch is different than the original, and should also be reviewed and validated by its original author. 🙏 

## Details
- Keep buffer between two tries to avoid SSL warning
- Use `socket.send` instead of `sendall` for better exception catching
- Set `select.select` timeout to `0` to avoid to block processing while waiting

## References
- GH-91
