### PR TITLE
CI: Fail workflow if coverage uploading to Codecov fails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,7 @@ jobs:
         pytest
 
     - name: Upload coverage to Codecov
+      if: ${{ matrix.python-version != '2.7' }}
       uses: codecov/codecov-action@v5
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -67,4 +68,4 @@ jobs:
         flags: unittests
         env_vars: OS,PYTHON
         name: codecov-umbrella
-        fail_ci_if_error: false
+        fail_ci_if_error: true


### PR DESCRIPTION
## About
After adding the authentication tokens for Codecov, this PR should succeed CI, and it does. ✅ 

## References
- GH-94
