### PR TITLE
Testing: Downgrade `pytest-cov` for testing Dependabot

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(name='xmpppy',
           "test": [
               "pathlib2; python_version<'3'",
               "pytest<10",
-              "pytest-cov<8",
+              "pytest-cov<7",
               "pytz",
           ],
       }


### PR DESCRIPTION
Just for CI validation purposes.
- https://github.com/xmpppy/xmpppy/issues/94#issuecomment-3797471687