### PR TITLE
Tests: Make software tests work without Docker

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,7 @@ jobs:
     - name: Run software tests
       run: |
         docker compose --file tests/compose.yml up --detach --wait
+        docker compose --file=tests/compose.yml exec prosody prosodyctl register testdrive localhost secret
         pytest
 
     - name: Upload coverage to Codecov

--- a/README.rst
+++ b/README.rst
@@ -106,6 +106,9 @@ within the code base.
 Development
 ***********
 
+Sandbox
+=======
+
 Acquire sources and bootstrap sandbox::
 
     git clone https://github.com/xmpppy/xmpppy
@@ -114,21 +117,32 @@ Acquire sources and bootstrap sandbox::
     source .venv/bin/activate
     pip install --upgrade --editable='.[test]'
 
+Software tests
+==============
+
+Running the software tests requires a local XMPP server and a specific user account.
+
+:TCP (ipv4):    ``localhost:5222``
+:XMPP vhost:    ``localhost``
+:JID:           ``testdrive@localhost``
+:Password:      ``secret``
+
+The server needs to support the core XMPP specification, it does not need to
+federate with other servers, nor provide TLS upgrades or other remote accesses.
+
 Run software tests::
 
-    # Provide an XMPP server on `localhost`.
-    # Ensure user account `testdrive` with password `secret` exists.
-    pytest
-
-Run software tests using Prosody in Docker::
-
-    docker compose --file=tests/compose.yml up
-    docker compose --file=tests/compose.yml exec prosody prosodyctl register testdrive localhost secret
     pytest
 
 Run particular test cases::
 
     pytest --no-cov -k compile
+
+Run software tests using Prosody XMPP through the accompanied Compose file::
+
+    docker compose --file=tests/compose.yml up
+    docker compose --file=tests/compose.yml exec prosody prosodyctl register testdrive localhost secret
+    pytest
 
 
 *******

--- a/README.rst
+++ b/README.rst
@@ -116,10 +116,17 @@ Acquire sources and bootstrap sandbox::
 
 Run software tests::
 
-    docker compose --file tests/compose.yml up
+    # Provide an XMPP server on `localhost`.
+    # Ensure user account `testdrive` with password `secret` exists.
     pytest
 
-Run particular tests::
+Run software tests using Prosody in Docker::
+
+    docker compose --file=tests/compose.yml up
+    docker compose --file=tests/compose.yml exec prosody prosodyctl register testdrive localhost secret
+    pytest
+
+Run particular test cases::
 
     pytest --no-cov -k compile
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,11 +24,3 @@ def timestamp_iso():
     now = dt.datetime.now(tz=pytz.timezone("Europe/Berlin"))
     now = now - dt.timedelta(microseconds=now.microsecond)
     return now.isoformat()
-
-
-@pytest.fixture(autouse=True)
-def prosody_register_user(run):
-    try:
-        run("docker compose --file=tests/compose.yml exec prosody prosodyctl register testdrive localhost secret")
-    except:
-        logger.error("Failed to register XMPP user. Subsequent tests will likely fail. Is Prosody running?")


### PR DESCRIPTION
## About
- Tests: Make software tests work without strictly needing Docker.
- README: Improve instructions how to invoke tests alternatively.

## References
- GH-111