### PR TITLE
Fix `UnicodeDecodeError` while logging large stanzas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ xmpppy changelog
 
 in progress
 ===========
+- Fixed ``UnicodeDecodeError`` while logging large stanzas by using ``backslashreplace`` handler.
+  Thanks, @vthriller and @normanr.
 
 2026-02-08 0.7.3
 ================

--- a/xmpp/debug.py
+++ b/xmpp/debug.py
@@ -397,7 +397,7 @@ class Debug:
 
     colors={}
     def Show(self, flag, msg, prefix=''):
-        msg=ensure_str(msg,'utf-8')
+        msg=ensure_str(msg,'utf-8','backslashreplace')
         msg=msg.replace('\r','\\r').replace('\n','\\n').replace('><','>\n  <')
         if not colors_enabled: pass
         elif prefix in self.colors: msg=self.colors[prefix]+msg+color_none


### PR DESCRIPTION
## About
Use `ensure_str(msg,'backslashreplace')` in `Debug.Show`, as suggested by @normanr.

## References
- GH-78